### PR TITLE
Changed module support to export the tagger instance

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -15,9 +15,7 @@
     if (typeof define === 'function' && define.amd) {
         define([], factory);
     } else if (typeof module === 'object' && module.exports) {
-        module.exports = function(root) {
-            return factory();
-        };
+        module.exports = factory();
     } else {
         root.tagger = factory();
     }


### PR DESCRIPTION
Changed module support to export the tagger instance, not a function that returns a new tagger instance.