### PR TITLE
completion.list type declaration is incorrect

### DIFF
--- a/tagger.d.ts
+++ b/tagger.d.ts
@@ -15,7 +15,7 @@ declare namespace Tagger {
     type completion_function = () => TypeOrPromise<string[]>;
     type completion_list = string[] | completion_function;
     interface completion {
-        list: completion;
+        list: completion_list;
         delay: number;
         min_length: number;
     }


### PR DESCRIPTION
In `tagger.d.ts`, the type for the `list` property of the `completion` interface is set to the wrong type. It should be `completion_list` instead of `completion`. As is, the definition is circular and all type checking for the `list` property will fail.