### PR TITLE
Autocomplete updates to tagger.js

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -243,9 +243,9 @@
             if (list.length) {
                 var id = 'tagger-completion-' + this._id;
                 if (!this._settings.allow_duplicates)
-                	list = list.filter(x => !this._tags.includes(x));
+                    list = list.filter(x => !this._tags.includes(x));
                 var datalist = create('datalist', {id: id}, list.map(function(tag) {
-                	return ['option', {}, [tag]];
+                    return ['option', {}, [tag]];
                 }));
                 this._completion.appendChild(datalist);
             }

--- a/tagger.js
+++ b/tagger.js
@@ -200,10 +200,10 @@
                         self._new_input_tag.value = '';
                     }
                 } else {
-                    if (typeof self._settings.completion.list === 'function') {
+                	var min = self._settings.completion.min_length;
+                    if (typeof self._settings.completion.list === 'function' && value.length >= min) {
                         self.complete(value);
                     }
-                    var min = self._settings.completion.min_length;
                     self._toggle_completion(value.length >= min);
                 }
             });
@@ -242,8 +242,10 @@
             this._last_completion = list;
             if (list.length) {
                 var id = 'tagger-completion-' + this._id;
+                if (!this._settings.allow_duplicates)
+                	list = list.filter(x => !this._tags.includes(x));
                 var datalist = create('datalist', {id: id}, list.map(function(tag) {
-                    return ['option', {}, [tag]];
+                	return ['option', {}, [tag]];
                 }));
                 this._completion.appendChild(datalist);
             }

--- a/tagger.js
+++ b/tagger.js
@@ -242,8 +242,9 @@
             this._last_completion = list;
             if (list.length) {
                 var id = 'tagger-completion-' + this._id;
-                if (!this._settings.allow_duplicates)
+                if (!this._settings.allow_duplicates) {
                     list = list.filter(x => !this._tags.includes(x));
+                }
                 var datalist = create('datalist', {id: id}, list.map(function(tag) {
                     return ['option', {}, [tag]];
                 }));


### PR DESCRIPTION
This change makes two enhancements to autocomplete:

1. In _new_input_tag.addEventListener, the previous code would call the autocomplete function even if completion.min_length hadn't been met yet. This request corrects the logic so that the function isn't called unless the character limit has been reached.

2. In _build_completion, the previous code would allow autocomplete to suggest a tag that already existed, even if allow_duplicates was set to false. This request adds an array filter to remove existing tags from autocomplete options if allow_duplicates is false.