### PR TITLE
Allow tab key to move focus when tag limit is reached

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -187,7 +187,7 @@
                     }
                     self._toggle_completion(true);
                     event.preventDefault();
-                } else if (self._tag_limit()) {
+                } else if (self._tag_limit() && event.keyCode !== 9) { // tab
                     event.preventDefault();
                 }
             });


### PR DESCRIPTION
When a tag limit is set and the maximum is reached allow the tab key to take focus away and move to the next input