### PR TITLE
Fix wrapping and whitespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ export default App
 
 ### Options:
 
-* **wrap** (default false)
+* **wrap** (default false) allow tags to wrap onto new lines instead of overflow scroll
 * **allow_duplicates** (default false)
 * **allow_spaces** (default true)
 * **add_on_blur** (default false)

--- a/demo.html
+++ b/demo.html
@@ -40,6 +40,7 @@
   var t3 = tagger(document.querySelectorAll('[name^="tags3"]'), {
       allow_duplicates: false,
       allow_spaces: true,
+      wrap: true,
       link: function(name) {
           return `javascript:alert('${name}');`;
       }

--- a/tagger.css
+++ b/tagger.css
@@ -14,25 +14,27 @@
     border: 1px solid #909497;
 }
 .tagger input[type="hidden"] {
-  /* fix for bootsrap */
+  /* fix for bootstrap */
   display: none;
 }
 .tagger > ul {
     display: flex;
     width: 100%;
     align-items: center;
-    padding: 4px 0;
+    padding: 4px 5px 0;
     justify-content: space-between;
     box-sizing: border-box;
     height: auto;
+    flex: 0 0 auto;
+    overflow-y: scroll;
 }
 .tagger ul {
     margin: 0;
     list-style: none;
 }
 .tagger > ul > li {
-    margin: .4rem 0;
-    padding-left: 10px;
+    padding-bottom: 0.4rem;
+    margin: 0.4rem 5px 4px;
 }
 .tagger > ul > li:not(.tagger-new) a,
 .tagger > ul > li:not(.tagger-new) a:visited,
@@ -48,10 +50,14 @@
     border: 1px solid #4181ed;
     border-radius: 3px;
 }
+.tagger li:not(.tagger-new) > span,
+.tagger > ul > li:not(.tagger-new) > a > span {
+    white-space: nowrap;
+}
 .tagger li a.close {
     padding: 4px;
     margin-left: 4px;
-    /* for bootsrap */
+    /* for bootstrap */
     float: none;
     filter: alpha(opacity=100);
     opacity: 1;
@@ -75,6 +81,7 @@
 .tagger .tagger-new {
     flex-grow: 1;
     position: relative;
+    min-width: 40px;
 }
 .tagger .tagger-new ul {
     padding: 5px;

--- a/tagger.css
+++ b/tagger.css
@@ -27,8 +27,6 @@
     height: auto;
     flex: 0 0 auto;
     overflow-y: scroll;
-}
-.tagger ul {
     margin: 0;
     list-style: none;
 }
@@ -37,20 +35,17 @@
     margin: 0.4rem 5px 4px;
 }
 .tagger > ul > li:not(.tagger-new) a,
-.tagger > ul > li:not(.tagger-new) a:visited,
-.tagger-new ul a,
-.tagger-new ul a:visited {
+.tagger > ul > li:not(.tagger-new) a:visited {
+    text-decoration: none;
     color: black;
 }
-.tagger > ul > li:not(.tagger-new) > a,
-.tagger li:not(.tagger-new) > span,
-.tagger .tagger-new ul {
+.tagger > ul > li:not(.tagger-new) > :first-child {
     padding: 4px 4px 4px 8px;
     background: #B1C3D7;
     border: 1px solid #4181ed;
     border-radius: 3px;
 }
-.tagger li:not(.tagger-new) > span,
+.tagger > ul > li:not(.tagger-new) > span,
 .tagger > ul > li:not(.tagger-new) > a > span {
     white-space: nowrap;
 }
@@ -67,9 +62,6 @@
 .tagger li a.close:hover {
     color: white;
 }
-.tagger li:not(.tagger-new) a {
-    text-decoration: none;
-}
 .tagger .tagger-new input {
     border: none;
     outline: none;
@@ -82,13 +74,6 @@
     flex-grow: 1;
     position: relative;
     min-width: 40px;
-}
-.tagger .tagger-new ul {
-    padding: 5px;
-}
-.tagger .tagger-completion {
-    position: absolute;
-    z-index: 100;
 }
 .tagger.wrap > ul {
     flex-wrap: wrap;

--- a/tagger.css
+++ b/tagger.css
@@ -26,7 +26,7 @@
     box-sizing: border-box;
     height: auto;
     flex: 0 0 auto;
-    overflow-y: scroll;
+    overflow-y: auto;
     margin: 0;
     list-style: none;
 }

--- a/tagger.js
+++ b/tagger.js
@@ -120,7 +120,6 @@
     tagger.fn = tagger.prototype = {
         init: function(input, settings) {
             this._id = ++id;
-            var self = this;
             this._settings = settings || {};
             this._ul = document.createElement('ul');
             this._input = input;
@@ -157,6 +156,8 @@
                 if (event.target.className.match(/close/)) {
                     self._remove_tag(event.target);
                     event.preventDefault();
+                } else if (event.target.tagName === 'UL') { //Focus new input when clicking in the whitespace of the Tagger instance
+                    self._new_input_tag.focus();
                 }
             });
             if (this._settings.add_on_blur) {


### PR DESCRIPTION
- Closes #28 -> Implemented with overflow-y scroll of Tagger container along with auto focus to input when clicking in container whitespace
- Closed #29 -> White space nowrap set along with fix for #28 
- Modified CSS for tag display to ensure vertical margin between tags when wrapping is set to true
- Simplified CSS and removed styles related to old pre-datalist autocompletion