### PR TITLE
Trigger a change event when original input value is updated.

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -149,6 +149,10 @@
                 this._build_completion(this._settings.completion.list);
             }
         },
+        _update_input: function () {
+          this._input.value = this._tags.join(',');
+          this._input.dispatchEvent(new Event('change', { bubbles: true }))
+        },
         // --------------------------------------------------------------------------------------
         _add_events: function() {
             var self = this;
@@ -180,7 +184,7 @@
                         var li = self._ul.querySelector('li:nth-last-child(2)');
                         self._ul.removeChild(li);
                         self._tags.pop();
-                        self._input.value = self._tags.join(',');
+                        self._update_input()
                     }
                     event.preventDefault();
                 } else if (event.keyCode === 32 && (event.ctrlKey || event.metaKey)) {
@@ -305,7 +309,7 @@
             }
             this._new_tag(name);
             this._tags.push(name);
-            this._input.value = this._tags.join(',');
+            this._update_input()
             return true;
         },
         // --------------------------------------------------------------------------------------
@@ -327,7 +331,7 @@
             this._tags = this._tags.filter(function(tag) {
                 return name !== tag;
             });
-            this._input.value = this._tags.join(',');
+            this._update_input()
             if (remove_dom) {
                 var tags = Array.from(this._ul.querySelectorAll('.label'));
                 var re = new RegExp('^\s*' + escape_regex(name) + '\s*$');


### PR DESCRIPTION
When tagger updates the original input field with the list of tags, there's currently no easy way to subscribe to those changes and trigger further actions, whether you're using vanilla JavaScript, React, or something else.

This pull requests has tagger trigger the `change` event hook when it writes to the input field's value, allowing for further integrations.