### PR TITLE
Update tagger.css

### DIFF
--- a/tagger.css
+++ b/tagger.css
@@ -19,6 +19,7 @@
 }
 .tagger > ul {
     display: flex;
+    flex-wrap:wrap;
     width: 100%;
     align-items: center;
     padding: 4px 5px 0;
@@ -77,5 +78,4 @@
 }
 .tagger.wrap > ul {
     flex-wrap: wrap;
-    justify-content: start;
 }


### PR DESCRIPTION
I have removed the "justify-content: start". It was causing an extra space in the input with made the tags break the lines. 

I have also set flex-wrap to wrap; In the second input as it was making the tags flow outside the screen.