### PR TITLE
Improve tagger initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ yarn add @jcubic/tagger
 tagger(document.querySelector('[name="tags"]'), {allow_spaces: false});
 ```
 
+Multiple inputs can be created by passing a NodeList or array of elements (eg. document.querySelectorAll()). If only one element is contained in the list then tagger will return the tagger instance, an array of tagger instances will be returned if the number of elements is greater than 1.
+
 ## Usage with React
 
 Tagger can easily be used with ReactJS.

--- a/tagger.js
+++ b/tagger.js
@@ -3,7 +3,7 @@
  * |_   _|___ ___ ___ ___ ___
  *   | | | .'| . | . | -_|  _|
  *   |_| |__,|_  |_  |___|_|
- *           |___|___|   version 0.4.4
+ *           |___|___|   version 0.4.5
  *
  * Tagger - Zero dependency, Vanilla JavaScript Tag Editor
  *
@@ -30,6 +30,11 @@
     })();
     // ------------------------------------------------------------------------------------------
     function tagger(input, options) {
+        if (input.length === 0) {
+            return;
+        } else if (input.length === 1) {
+            input = Array.from(input).pop();
+        }
         if (input.length) {
             return Array.from(input).map(function(input) {
                 return new tagger(input, options);


### PR DESCRIPTION
 * Return without creation if an empty NodeList or iterable is passed in
 * Flatten a NodeList or iterable if it contains a single element
 * Document the return type of tagger() in the readme to cover the single element in list case

 Closes #23