### PR TITLE
Support setting an input placeholder value to improve UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ export default App
 * **completion** `{list: string[] | function(): Promise(string[])|string[], delay: miliseconds, min_length: number}`
 * **link** `function(name): string|false` it should return what should be in href attribute or false
 * **tag_limit** `number` (default -1) limit number of tags, when set to -1 there are no limits
+* **placeholder** `string` (default unset) If set in options or on the initial input, this placeholder value will be shown in the tag entry input
 
 **NOTE:** if you're familiar with TypeScript you can check the API by looking at
 TypeScript definition file:

--- a/tagger.js
+++ b/tagger.js
@@ -129,12 +129,18 @@
             } else {
                 wrapper.className = 'tagger';
             }
+            if (!settings.placeholder && this._input.hasAttribute('placeholder')) {
+                settings.placeholder = this._input.placeholder;
+            }
             this._input.setAttribute('hidden', 'hidden');
             this._input.setAttribute('type', 'hidden');
             var li = document.createElement('li');
             li.className = 'tagger-new';
             this._new_input_tag = document.createElement('input');
             this.tags_from_input();
+            if (settings.placeholder) {
+                this._new_input_tag.setAttribute('placeholder', settings.placeholder);
+            }
             li.appendChild(this._new_input_tag);
             this._completion = document.createElement('div');
             this._completion.className = 'tagger-completion';


### PR DESCRIPTION
This allows you to set the value of placeholder in the tagger input field.