### PR TITLE
Implement filter callback to optionally modify or suppress the tag creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ export default App
 * **link** `function(name): string|false` it should return what should be in href attribute or false
 * **tag_limit** `number` (default -1) limit number of tags, when set to -1 there are no limits
 * **placeholder** `string` (default unset) If set in options or on the initial input, this placeholder value will be shown in the tag entry input
+* **filter** `function(name): string` it should return the tag name after applying any filters (eg String.toUpperCase()), empty string to filter out tag and prevent creation.
 
 **NOTE:** if you're familiar with TypeScript you can check the API by looking at
 TypeScript definition file:

--- a/tagger.d.ts
+++ b/tagger.d.ts
@@ -20,6 +20,7 @@ declare namespace Tagger {
         min_length: number;
     }
     type link = (name: string) => (string | false);
+    type filter = (name: string) => (string);
 }
 
 interface tagger_options {
@@ -31,6 +32,7 @@ interface tagger_options {
     completion?: Tagger.completion;
     link?: Tagger.link;
     placeholder?: string;
+    filter?: Tagger.filter;
 }
 
 interface tagger_instance {

--- a/tagger.js
+++ b/tagger.js
@@ -119,7 +119,8 @@
         add_on_blur: false,
         link: function(name) {
             return '/tag/' + name;
-        }
+        },
+        filter: (name) => name,
     };
     // ------------------------------------------------------------------------------------------
     tagger.fn = tagger.prototype = {
@@ -305,13 +306,14 @@
         },
         // --------------------------------------------------------------------------------------
         add_tag: function(name) {
-            if (!this._settings.allow_duplicates && this._tags.indexOf(name) !== -1) {
-                return false;
-            }
             if (this._tag_limit()) {
                 return false;
             }
+            name = this._settings.filter(name);
             if (this.is_empty(name)) {
+                return false;
+            }
+            if (!this._settings.allow_duplicates && this._tags.indexOf(name) !== -1) {
                 return false;
             }
             this._new_tag(name);


### PR DESCRIPTION
Implement a filter callback method to optionally modify the tag before creation, for example making all tags Upper case. Filter can also suppress creation of the tag by returning an empty string.

Filter should be provided via option filter with the signature `function(name): string`

Closes #14, Closes #34