### PR TITLE
[feat]: add additional delimiters support for tag creation

### DIFF
--- a/tagger.d.ts
+++ b/tagger.d.ts
@@ -21,8 +21,8 @@ declare namespace Tagger {
     }
     type link = (name: string) => (string | false);
     type filter = (name: string) => (string);
+    type additional_delimiters = Array<(";")>
 }
-
 interface tagger_options {
     wrap?: boolean;
     allow_duplicates?: boolean;
@@ -33,6 +33,7 @@ interface tagger_options {
     link?: Tagger.link;
     placeholder?: string;
     filter?: Tagger.filter;
+    additional_delimiters?: Tagger.additional_delimiters
 }
 
 interface tagger_instance {

--- a/tagger.js
+++ b/tagger.js
@@ -121,6 +121,7 @@
             return '/tag/' + name;
         },
         filter: (name) => name,
+        additional_delimiters: []
     };
     // ------------------------------------------------------------------------------------------
     tagger.fn = tagger.prototype = {
@@ -189,6 +190,7 @@
             // ----------------------------------------------------------------------------------
             this._new_input_tag.addEventListener('keydown', function(event) {
                 if (event.keyCode === 13 || event.keyCode === 188 ||
+                    self._settings.additional_delimiters.includes(event.key) ||
                     (event.keyCode === 32 && !self._settings.allow_spaces)) { // enter || comma || space
                     if (self.add_tag(self._new_input_tag.value.trim())) {
                         self._new_input_tag.value = '';


### PR DESCRIPTION
- Added support for ```additional_delimiters``` for creating new tags.
- Add type definitions for new parameter named ```additional_delimiters```.