### PR TITLE
Fix: can’t delete tag containing multiple consecutive spaces

### DIFF
--- a/tagger.js
+++ b/tagger.js
@@ -365,7 +365,7 @@
         // --------------------------------------------------------------------------------------
         _remove_tag: function(close) {
             var li = close.closest('li');
-            var name = li.querySelector('.label').innerText;
+            var name = li.querySelector('.label').textContent;
             this._ul.removeChild(li);
             this.remove_tag(name, false);
         }


### PR DESCRIPTION
When deleting tags that contain multiple spaces, using innerText will compress multiple spaces into one. Therefore, use textContent to fix this.
![image](https://github.com/jcubic/tagger/assets/91713418/3d83dc06-96a7-4fae-98a5-dbf6fb4beb1b)
